### PR TITLE
Correção do método testSaveActionPostRequest() para incluir o parâmetro ...

### DIFF
--- a/module/Skel/tests/src/Skel/Controller/IndexControllerTest.php
+++ b/module/Skel/tests/src/Skel/Controller/IndexControllerTest.php
@@ -92,6 +92,7 @@ class IndexControllerTest extends ControllerTestCase
         $this->routeMatch->setParam('action', 'save');
         
         $this->request->setMethod('post');
+        $this->request->getPost()->set('id', '');
         $this->request->getPost()->set('title', 'Apple compra a Coderockr');
         $this->request->getPost()->set(
             'body', 'A Apple compra a <b>Coderockr</b><br> '


### PR DESCRIPTION
...id no POST

O parâmetro id está marcado para "required" no inputFilter do Model, então é necessário incluí-lo na requisição para que o teste passe.
