### PR TITLE
Desabilitado o carregamento do módulo Skel

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -3,7 +3,7 @@ return array(
     'modules' => array(
         'Application',
         'Core',
-        'Skel'
+        //'Skel'
     ),
     'module_listener_options' => array(
         'config_glob_paths'    => array(


### PR DESCRIPTION
O módulo Skel tem, em sua configuração, uma chave para banco de dados - esta chave estava sobreescrevendo a configuração do banco global. Visto que é um módulo de template acho que a melhor solução é deixar desabilitado.
